### PR TITLE
Implement strided data loading to reduce memory usage.

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ CONFIG_V3 = {
     "num_workers": 8,
     "generate_dummy_data_if_empty": True,
     "force_reprocess_data": True,
+    "data_stride": 256,
 
     # Embedding Layer
     "embedding_dim": 512,


### PR DESCRIPTION
This change introduces a 'data_stride' parameter to control the step size when creating sequences from the dataset. By sampling sequences with a stride, instead of at every byte, the total number of sequences is significantly reduced, preventing Out-Of-Memory errors.

Key changes:
- Added `data_stride` to `config.py`.
- Modified `ByteSequenceDataset` in `dataset.py` to:
    - Accept a `stride` parameter in `__init__`.
    - Calculate dataset size based on `stride`.
    - Retrieve items using `stride` in `__getitem__`.
- Updated `DataProcessor` in `dataset.py` to pass `stride` to `ByteSequenceDataset`.
- Updated `main.py` to read `data_stride` from config and pass it to the data loading components.