### PR TITLE
Feat: Implement Curved Feed-Forward Networks

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,6 +50,11 @@ CONFIG_V3 = {
     "attention_d_model": 1024,
     "attention_num_heads": 16,
     "attention_dropout": 0.2,
+
+    # --- FFN Curvature Settings ---
+    "use_curved_ffn": True,           # Enable/disable the curved FFN feature.
+    "ffn_gamma": -1.2,                # The curvature parameter γ'. Negative values accelerate dynamics.
+
     "ffn_dim_multiply": 4,
     "transformer_dropout": 0.2,
     "transformer_norm_first": False, # Set to True for Pre-LN Transformers


### PR DESCRIPTION
This commit introduces "curved" Feed-Forward Networks (FFNs) into the ByteLLM_GrugV3 model, based on the principles from the paper "Explosive neural networks via higher-order interactions in curved statistical manifolds."

This is achieved by introducing a state-dependent modulation within the FFNs, analogous to an "effective inverse temperature" (β'). This allows for the introduction of higher-order interactions without altering the fundamental model architecture.

Changes include:
- A new `CurvedFeedForward` module in `model_components.py` that contains the core logic for the curvature modulation.
- A `CustomTransformerEncoderLayer` that can use either the standard FFN or the new `CurvedFeedForward` module.
- Configuration options (`use_curved_ffn`, `ffn_gamma`) in `config.py` to enable and control the new feature.
- The `ByteLLM_GrugV3` model in `model.py` is updated to use the `CustomTransformerEncoderLayer`, allowing both single-stream and parallel-stream architectures to leverage the curved FFNs.